### PR TITLE
Fix: Shade ACF and update plugin.yml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,27 @@
             </goals>
             <configuration>
               <createDependencyReducedPom>false</createDependencyReducedPom>
-              <!-- We don't want to shade dependencies that satellite plugins will use from the core -->
+              <relocations>
+                <relocation>
+                  <pattern>co.aikar.commands</pattern>
+                  <shadedPattern>com.cufufy.cufufycore.lib.acf</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>co.aikar.locales</pattern>
+                  <shadedPattern>com.cufufy.cufufycore.lib.locales</shadedPattern>
+                </relocation>
+              </relocations>
               <artifactSet>
+                <includes>
+                  <include>co.aikar:acf-paper</include>
+                </includes>
                 <excludes>
-                  <exclude>co.aikar:acf-paper</exclude>
-                  <exclude>com.zaxxer:HikariCP</exclude>
-                  <exclude>org.bstats:*</exclude>
+                  <!-- Exclude HikariCP and bStats if they are intended to be used as separate plugins or provided by another core plugin -->
+                  <!-- For this case, we assume CufufyCore might be the one providing them, so they are NOT excluded here by default. -->
+                  <!-- If other plugins are also shading HikariCP or bStats, you might want to exclude them -->
+                  <!-- <exclude>com.zaxxer:HikariCP</exclude> -->
+                  <!-- <exclude>org.bstats:*</exclude> -->
+
                   <!-- Lombok is compile-time only, but good practice to exclude if ever not 'provided' -->
                   <exclude>org.projectlombok:lombok</exclude>
                 </excludes>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,8 +2,10 @@ name: CufufyCore
 version: '${project.version}' # Use version from pom.xml
 main: com.cufufy.cufufyCore.CufufyCore
 api-version: '1.21'
-depend:
-  - acf
+# ACF is now shaded, so it's not an external plugin dependency.
+# If you had other actual plugin dependencies, they would go here.
+# depend:
+#  - OtherPlugin
 authors: [YourName] # TODO: Replace with actual author
 description: Core plugin for Cufufy project, providing shared functionalities.
 website: https://www.example.com # TODO: Replace with actual website


### PR DESCRIPTION
- Modified pom.xml to correctly shade co.aikar:acf-paper into the plugin JAR and relocate its packages to avoid conflicts.
- Removed 'acf' from the 'depend' list in plugin.yml as it's now bundled with the core plugin.

This resolves the UnknownDependencyException for ACF that occurred on server startup.